### PR TITLE
chore: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @justincase-jp/frontend


### PR DESCRIPTION
@justincase-jp/frontend を全員Codeowner に指定しました。
TeamをCodeownerに指定した際の仕様としては、
- PR作成時のレビュー通知→チーム全員に通知
- 誰かがレビューした後の通知→レビュワーが立候補制で決まったものとみなされ、その人だけに通知
という感じのようです。

