### PR TITLE
jictのQiitaオーガナイゼーションのrssを追加

### DIFF
--- a/members.ts
+++ b/members.ts
@@ -8,6 +8,7 @@ export const members: Member[] = [
     avatarSrc: "https://github.com/justincase-jp.png",
     sources: [
       "https://jict.hatenablog.com/rss",
+      "https://qiita.com/organizations/justincase/activities.atom",
     ],
     twitterUsername: "justInCaseHoken",
     githubUsername: "justincase-jp",


### PR DESCRIPTION
SSIA

## 個人的な提案
基本的には`Qiita`のオーガナイゼーションに参加して頂く形で、他の方の`sources`には個人ブログやオーガナイゼーション参加したくない`Qiita`アカウントを入れる形にするとダブりが出なくなっていいかなと思いました。
いかがでしょうか？